### PR TITLE
add thread safety around the BufferedTokenizer usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Fixed thread safety issue. See https://github.com/logstash-plugins/logstash-codec-line/pull/13
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-line'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads line-oriented text data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #4 
Related to elastic/logstash/issues/8830

This PR adds thread safety around the `BufferedTokenizer` usage. This codec when used in multiple thread, for example in the udp input plugin with multiple workers,  was crashing because of the thread unsafe handling of the `BufferedTokenizer`.

- This has been tested & validated manually. Using this I was able to easily reproduce the problem and asses that it was solved.
```
 bin/logstash -e 'input { udp { codec => line  workers => 4 port => 5015  } } output { stdout { codec => dots } }'
```
```
yes "The quick brown fox jumps over the lazy dog" | nc -u localhost 5015
```

- I verified the performance impact and there is no noticeable impact when running in a single thread with or without the fix and there is a performance **increase** with the fix when using multiple thread since without the fix, threads were dying one by one until a single one remained. 
