### PR TITLE
remove thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.7
+  - Reverted thread safety fix and instead fixed udp input codec per worker. See https://github.com/logstash-plugins/logstash-codec-line/pull/14
+
 ## 3.0.6
   - Fixed thread safety issue. See https://github.com/logstash-plugins/logstash-codec-line/pull/13
 

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-line'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads line-oriented text data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Per discussion in  elastic/logstash#8830 and new codec instance per udp input worker, see logstash-plugins/logstash-input-udp/pull/32 thread safety is unnecessary in the line codec.