### PR TITLE
Feat: ECS + event_factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: ECS + event_factory support [#18](https://github.com/logstash-plugins/logstash-codec-line/pull/18) 
+
 ## 3.0.8
   - Code cleanup. See https://github.com/logstash-plugins/logstash-codec-line/pull/15
 

--- a/lib/logstash/codecs/line.rb
+++ b/lib/logstash/codecs/line.rb
@@ -2,12 +2,19 @@
 require "logstash/codecs/base"
 require "logstash/util/charset"
 
+require 'logstash/plugin_mixins/ecs_compatibility_support'
+require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+
 # Line-oriented text data.
 #
 # Decoding behavior: Only whole line events will be emitted.
 #
 # Encoding behavior: Each event will be emitted with a trailing newline.
 class LogStash::Codecs::Line < LogStash::Codecs::Base
+
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
+  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
+
   config_name "line"
 
   # Set the desired text format for encoding.
@@ -35,13 +42,13 @@ class LogStash::Codecs::Line < LogStash::Codecs::Base
   end
 
   def decode(data)
-    @buffer.extract(data).each { |line| yield LogStash::Event.new(MESSAGE_FIELD => @converter.convert(line)) }
+    @buffer.extract(data).each { |line| yield new_event_from_line(line) }
   end
 
   def flush(&block)
     remainder = @buffer.flush
     if !remainder.empty?
-      block.call(LogStash::Event.new(MESSAGE_FIELD => @converter.convert(remainder)))
+      block.call new_event_from_line(remainder)
     end
   end
 
@@ -49,4 +56,11 @@ class LogStash::Codecs::Line < LogStash::Codecs::Base
     encoded = @format ? event.sprintf(@format) : event.to_s
     @on_event.call(event, encoded + @delimiter)
   end
+
+  private
+
+  def new_event_from_line(line)
+    event_factory.new_event(MESSAGE_FIELD => @converter.convert(line))
+  end
+
 end

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-line'
-  s.version         = '3.0.8'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads line-oriented text data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -22,9 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3', '< 2'
-  s.add_runtime_dependency "logstash-mixin-event_support", '< 2'
+  s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'
 end
-

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3', '< 2'
+  s.add_runtime_dependency "logstash-mixin-event_support", '< 2'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-line.gemspec
+++ b/logstash-codec-line.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3', '< 2'
+  s.add_runtime_dependency "logstash-mixin-ecs_compatibility_support", '~> 1.3'
   s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/codecs/line_spec.rb
+++ b/spec/codecs/line_spec.rb
@@ -72,6 +72,8 @@ describe LogStash::Codecs::Line, :ecs_compatibility_support do
         subject.decode(line) do |e|
           expect( e ).to be_a LogStash::Event
           expect( e.get("message") ).to eql message
+          expect( e.get("message").encoding ).to eql Encoding.find('UTF-8')
+          expect( e.get("message").valid_encoding? ).to be true
         end
       end
 

--- a/spec/codecs/line_spec.rb
+++ b/spec/codecs/line_spec.rb
@@ -4,8 +4,10 @@ require "logstash/devutils/rspec/spec_helper"
 require "insist"
 require "logstash/codecs/line"
 require "logstash/event"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
-describe LogStash::Codecs::Line do
+describe LogStash::Codecs::Line, :ecs_compatibility_support do
+
   subject do
     next LogStash::Codecs::Line.new
   end
@@ -57,11 +59,28 @@ describe LogStash::Codecs::Line do
       insist { decoded } == true
     end
 
-    it "should return an event from a valid utf-8 string" do
-      subject.decode("München\n") do |e|
-        insist { e.is_a?(LogStash::Event) }
-        insist { e.get("message") } == "München"
+    ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
       end
+
+      let(:message) { "München" }
+      let(:line) { "#{message}\n" }
+
+      it "should return an event from a valid utf-8 string" do
+        subject.decode(line) do |e|
+          expect( e ).to be_a LogStash::Event
+          expect( e.get("message") ).to eql message
+        end
+      end
+
+      it "sets event.original in ECS mode" do
+        subject.decode(line) do |event|
+          expect( event.get("[event][original]") ).to eql message
+        end
+      end if ecs_select.active_mode != :disabled
+
     end
 
     context "when using custom :delimiter" do


### PR DESCRIPTION
Added `ecs_compatibility` setting since we still want to set `event.original` in ECS mode.

Also, leveraging LS' `new_event` [factory interface](https://github.com/elastic/logstash/issues/13021).